### PR TITLE
Use 1.7.6 error message for modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 vendor/*
 config.xml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,19 @@
 ### How to install
 
  1. Download or clone module into `modules` directory of your PrestaShop installation
- 2. Make sure module directory is named `ps_democqrshooksusage`
+ 2. Rename the directory to make sure that module directory is named `ps_democqrshooksusage`*
  3. `cd` into module's directory and run following commands:
 	 - `composer dumpautoload` to generate autoloader for module
  4. Install module from Back Office
+
+*Because the name of the directory and the name of the main module file must match.
+
+### What it does
+
+This module adds a new field to Customer: a yes/no field "is allowed to review".
+This new field appears:
+- in the Customers listing as a new column
+- in the Customers Add/Edit form as a new field you can manage
+
+This modules shows how to add this field, manage its content and its
+properties using only hooks

--- a/ps_democqrshooksusage.php
+++ b/ps_democqrshooksusage.php
@@ -180,7 +180,7 @@ class Ps_DemoCQRSHooksUsage extends Module
     }
 
     /**
-     * Hook allows to modify Customers form and add aditional form fields as well as modify or add new data to the forms.
+     * Hook allows to modify Customers form and add additional form fields as well as modify or add new data to the forms.
      *
      * @param array $params
      */
@@ -216,7 +216,7 @@ class Ps_DemoCQRSHooksUsage extends Module
     }
 
     /**
-     * Hook allows to modify Customers form and add aditional form fields as well as modify or add new data to the forms.
+     * Hook allows to modify Customers form and add additional form fields as well as modify or add new data to the forms.
      *
      * @param array $params
      *
@@ -242,7 +242,7 @@ class Ps_DemoCQRSHooksUsage extends Module
     /**
      * @param array $params
      *
-     * @throws CustomerException
+     * @throws \PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorException
      */
     private function updateCustomerReviewStatus(array $params)
     {
@@ -308,6 +308,8 @@ class Ps_DemoCQRSHooksUsage extends Module
      * Handles exceptions and displays message in more user friendly form.
      *
      * @param ReviewerException $exception
+     *
+     * @throws \PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorException
      */
     private function handleException(ReviewerException $exception)
     {
@@ -326,24 +328,19 @@ class Ps_DemoCQRSHooksUsage extends Module
 
         $exceptionType = get_class($exception);
 
-        /** @var FlashBagInterface $flashBag */
-        $flashBag = $this->get('session')->getFlashBag();
-
         if (isset($exceptionDictionary[$exceptionType])) {
-            $flashBag->add('error', $exceptionDictionary[$exceptionType]);
-
-            return;
+            $message = $exceptionDictionary[$exceptionType];
+        } else {
+            $message = $this->getTranslator()->trans(
+                'An unexpected error occurred. [%type% code %code%]',
+                [
+                    '%type%' => $exceptionType,
+                    '%code%' => $exception->getCode(),
+                ],
+                'Admin.Notifications.Error'
+            );
         }
 
-        $fallbackMessage = $this->getTranslator()->trans(
-            'An unexpected error occurred. [%type% code %code%]',
-            [
-                '%type%' => $exceptionType,
-                '%code%' => $exception->getCode(),
-            ],
-            'Admin.Notifications.Error'
-        );
-
-        $flashBag->add('error', $fallbackMessage);
+        throw new \PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorException($message);
     }
 }

--- a/src/Controller/Admin/CustomerReviewController.php
+++ b/src/Controller/Admin/CustomerReviewController.php
@@ -13,8 +13,8 @@ namespace DemoCQRSHooksUsage\Controller\Admin;
 use DemoCQRSHooksUsage\Domain\Reviewer\Command\ToggleIsAllowedToReviewCommand;
 use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotCreateReviewerException;
 use DemoCQRSHooksUsage\Domain\Reviewer\Exception\CannotToggleAllowedToReviewStatusException;
+use DemoCQRSHooksUsage\Domain\Reviewer\Exception\ReviewerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerException;
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -45,7 +45,7 @@ class CustomerReviewController extends FrameworkBundleAdminController
             $this->getCommandBus()->handle(new ToggleIsAllowedToReviewCommand((int) $customerId));
 
             $this->addFlash('success', $this->trans('Successful update.', 'Admin.Notifications.Success'));
-        } catch (DomainException $e) {
+        } catch (ReviewerException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessageMapping()));
         }
 

--- a/src/Domain/Reviewer/Exception/ReviewerException.php
+++ b/src/Domain/Reviewer/Exception/ReviewerException.php
@@ -10,8 +10,6 @@
 
 namespace DemoCQRSHooksUsage\Domain\Reviewer\Exception;
 
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
-
-class ReviewerException extends DomainException
+class ReviewerException extends \Exception
 {
 }


### PR DESCRIPTION
Update module to use Module user-displayable exceptions to handle module errors introduced in https://github.com/PrestaShop/PrestaShop/pull/14239